### PR TITLE
Add Dockerfile + link to live in-browser demo

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,20 @@
+# Keep the build context small.
+.git
+.github
+__pycache__/
+*.pyc
+.pytest_cache
+.ruff_cache
+.venv
+venv
+htmlcov
+.coverage
+coverage.xml
+data/
+outputs/
+models/
+tests/
+docs/
+*.egg-info/
+build/
+dist/

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,21 @@ ENV PYTHONUNBUFFERED=1 \
 
 WORKDIR /app
 
-# Install the package with web extras (FastAPI + uvicorn + python-multipart).
-# Copy only what the build needs first so layers cache well.
+# Install dependencies first, against a stub package, so the heavy layer
+# (torch, sentence-transformers) stays cached when only src/ changes.
 COPY pyproject.toml README.md ./
+RUN mkdir -p src && touch src/__init__.py \
+    && pip install --upgrade pip \
+    && pip install ".[web]"
+
+# Add the real source and (re)install just the package itself — deps are
+# already present, so this stays fast on code-only changes.
 COPY src ./src
-RUN pip install --upgrade pip && pip install ".[web]"
+RUN pip install --no-deps ".[web]"
+
+# Run as a non-root user; ensure /app (incl. the HF cache dir) is writable.
+RUN useradd -m -u 8888 appuser && chown -R appuser:appuser /app
+USER appuser
 
 EXPOSE 8000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Minimal image for the GenAI Categorizer web service (CPU-only).
+#
+#   docker build -t genai-categorizer .
+#   docker run --rm -p 8000:8000 genai-categorizer
+#
+# The multilingual embedding model downloads on first request into HF_HOME;
+# mount a volume there to cache it across runs.
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    HF_HOME=/app/.cache/huggingface
+
+WORKDIR /app
+
+# Install the package with web extras (FastAPI + uvicorn + python-multipart).
+# Copy only what the build needs first so layers cache well.
+COPY pyproject.toml README.md ./
+COPY src ./src
+RUN pip install --upgrade pip && pip install ".[web]"
+
+EXPOSE 8000
+
+# The FastAPI app object lives at src.app:app. Bind to all interfaces so the
+# service is reachable from outside the container.
+CMD ["uvicorn", "src.app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 A Python tool that categorizes AI assistant conversations (Claude, ChatGPT) by topic using multilingual sentence embeddings and keyword-based classification. Analyze your conversation history to discover usage patterns across 12 topic categories with subcategory granularity.
 
+> **🔍 Try it in your browser** — a light, no-install version of the categorizer (keyword stage only, runs fully client-side, nothing uploaded) is live at **[mikekrohn.ai/tools/categorizer](https://mikekrohn.ai/tools/categorizer)**. Clone this repo for the full pipeline (embeddings, clustering, charts).
+
 ## Features
 
 - **Interactive web dashboard** — Drag-and-drop JSON or CSV files in your browser to instantly visualize conversation patterns with charts and a searchable data table
@@ -101,6 +103,25 @@ Open **http://localhost:8000** in your browser, then drag-and-drop your JSON or 
 - **Voice vs text** — voice conversation detection
 - **Confidence scores** — histogram of categorization confidence
 - **Searchable data table** — filter by category, complexity, or free-text search; sortable columns; click to expand text previews
+
+### Docker (run as a service)
+
+Build and run the web dashboard/API in a container — no local Python setup
+required:
+
+```bash
+docker build -t genai-categorizer .
+docker run --rm -p 8000:8000 genai-categorizer
+```
+
+Then open **http://localhost:8000**, or POST files to `http://localhost:8000/api/analyze`.
+
+Notes:
+- The image is CPU-only and pulls the CPU build of PyTorch. The
+  `paraphrase-multilingual-mpnet-base-v2` model (~569 MB) downloads on first
+  request, so the first analysis is slower (subsequent ones are fast).
+- To persist the model between runs, mount a cache volume:
+  `-v hf-cache:/app/.cache/huggingface`.
 
 ### CLI Pipeline
 


### PR DESCRIPTION
Makes the categorizer runnable as a service and links it to the live demo.

## Changes
- **`Dockerfile` + `.dockerignore`** — run the FastAPI web service/API in a container:
  ```bash
  docker build -t genai-categorizer .
  docker run --rm -p 8000:8000 genai-categorizer
  ```
  CPU-only image; installs the package via `pip install ".[web]"` and serves `src.app:app` with uvicorn on `0.0.0.0:8000`. The embedding model (~569 MB) downloads on first request into `HF_HOME` (mountable as a volume to persist).
- **README** — documents the Docker workflow and adds a "Try it in your browser" link to the light client-side demo at `mikekrohn.ai/tools/categorizer`.

## Notes
- No application code changed (Docker + docs only).
- The Docker image build was **not** exercised in CI here; it's based on the existing `pyproject.toml` packaging (`setuptools` find → `src`). Worth a local `docker build` before merge.

https://claude.ai/code/session_01KV9dDgRRisUNoS8ThGGW5J

---
_Generated by [Claude Code](https://claude.ai/code/session_01KV9dDgRRisUNoS8ThGGW5J)_