### PR TITLE
CI: make pip-audit green (ignore no-fix torch CVE)

### DIFF
--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -36,4 +36,6 @@ jobs:
           pip install pip-audit
 
       - name: Run vulnerability scan
-        run: pip-audit
+        # CVE-2025-3000 (torch) has no fixed version available upstream yet;
+        # ignore it so the scan still catches new, actionable vulnerabilities.
+        run: pip-audit --ignore-vuln CVE-2025-3000


### PR DESCRIPTION
The `Dependency Scan` (`pip-audit`) workflow fails on **CVE-2025-3000** in `torch`, which pip-audit reports as having **no fixed version available** upstream. It will stay red on every push/schedule until torch ships a fix — independent of any change here.

This adds `--ignore-vuln CVE-2025-3000` to the pip-audit step so the scan goes green while still surfacing any *new, actionable* vulnerabilities. The ignore is documented inline and can be removed once a fixed torch is released.

(Follow-up to #4, which merged with this pre-existing failure red.)

https://claude.ai/code/session_01KV9dDgRRisUNoS8ThGGW5J

---
_Generated by [Claude Code](https://claude.ai/code/session_01KV9dDgRRisUNoS8ThGGW5J)_